### PR TITLE
Add Clearance for user authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,19 +15,14 @@ gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.2'
 gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.5'
-# Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 4.0'
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
+gem 'clearance', '~> 1.16', '>= 1.16.1'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '~> 3.7'
   gem 'capybara', '~> 3.0', '>= 3.0.1'
   gem 'database_cleaner'
+  gem 'factory_bot_rails', '~> 4.8', '>= 4.8.2'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
+    bcrypt (3.1.11)
     bindex (0.5.0)
     builder (3.2.3)
     byebug (10.0.2)
@@ -51,6 +52,10 @@ GEM
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       xpath (~> 3.0)
+    clearance (1.16.1)
+      bcrypt
+      email_validator (~> 1.4)
+      rails (>= 3.1)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -62,8 +67,15 @@ GEM
     crass (1.0.4)
     database_cleaner (1.6.2)
     diff-lcs (1.3)
+    email_validator (1.6.0)
+      activemodel
     erubi (1.7.1)
     execjs (2.7.0)
+    factory_bot (4.8.2)
+      activesupport (>= 3.0.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
+      railties (>= 3.0.0)
     ffi (1.9.23)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -191,8 +203,10 @@ PLATFORMS
 DEPENDENCIES
   byebug
   capybara (~> 3.0, >= 3.0.1)
+  clearance (~> 1.16, >= 1.16.1)
   coffee-rails (~> 4.2)
   database_cleaner
+  factory_bot_rails (~> 4.8, >= 4.8.2)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg (~> 1.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
+  include Clearance::Controller
   protect_from_forgery with: :exception
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,3 @@
+class User < ApplicationRecord
+  include Clearance::User
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,5 +10,17 @@
 
   <body>
     <%= yield %>
+    <% if signed_in? %>
+      Signed in as: <%= current_user.email %>
+      <%= button_to 'Sign out', sign_out_path, method: :delete %>
+    <% else %>
+      <%= link_to 'Sign in', sign_in_path %>
+    <% end %>
+
+    <div id="flash">
+      <% flash.each do |key, value| %>
+        <div class="flash <%= key %>"><%= value %></div>
+      <% end %>
+    </div>
   </body>
 </html>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,6 +31,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,6 +28,7 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
@@ -39,4 +40,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  #
+  # Allow Clearance to use backdoors to sign in users
+  config.middleware.use Clearance::BackDoor
 end

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -1,0 +1,4 @@
+Clearance.configure do |config|
+  config.mailer_sender = "reply@example.com"
+  config.rotate_csrf_on_sign_in = true
+end

--- a/db/migrate/20180411130903_create_users.rb
+++ b/db/migrate/20180411130903_create_users.rb
@@ -1,0 +1,14 @@
+class CreateUsers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :users do |t|
+      t.timestamps null: false
+      t.string :email, null: false
+      t.string :encrypted_password, limit: 128, null: false
+      t.string :confirmation_token, limit: 128
+      t.string :remember_token, limit: 128, null: false
+    end
+
+    add_index :users, :email
+    add_index :users, :remember_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,26 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20180411130903) do
+
+  create_table "users", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "email", null: false
+    t.string "encrypted_password", limit: 128, null: false
+    t.string "confirmation_token", limit: 128
+    t.string "remember_token", limit: 128, null: false
+    t.index ["email"], name: "index_users_on_email"
+    t.index ["remember_token"], name: "index_users_on_remember_token"
+  end
+
+end

--- a/spec/factories/clearance.rb
+++ b/spec/factories/clearance.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  sequence :email do |n|
+    "user#{n}@example.com"
+  end
+
+  factory :user do
+    email
+    password "password"
+  end
+end

--- a/spec/features/clearance/user_signs_out_spec.rb
+++ b/spec/features/clearance/user_signs_out_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+require "support/features/clearance_helpers"
+
+RSpec.feature "User signs out" do
+  scenario "signs out" do
+    sign_in
+    sign_out
+
+    expect_user_to_be_signed_out
+  end
+end

--- a/spec/features/clearance/visitor_resets_password_spec.rb
+++ b/spec/features/clearance/visitor_resets_password_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+require "support/features/clearance_helpers"
+
+RSpec.feature "Visitor resets password" do
+  before { ActionMailer::Base.deliveries.clear }
+
+  around do |example|
+    original_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :inline
+    example.run
+    ActiveJob::Base.queue_adapter = original_adapter
+  end
+
+  scenario "by navigating to the page" do
+    visit sign_in_path
+
+    click_link I18n.t("sessions.form.forgot_password")
+
+    expect(current_path).to eq new_password_path
+  end
+
+  scenario "with valid email" do
+    user = user_with_reset_password
+
+    expect_page_to_display_change_password_message
+    expect_reset_notification_to_be_sent_to user
+  end
+
+  scenario "with non-user account" do
+    reset_password_for "unknown.email@example.com"
+
+    expect_page_to_display_change_password_message
+    expect_mailer_to_have_no_deliveries
+  end
+
+  private
+
+  def expect_reset_notification_to_be_sent_to(user)
+    expect(user.confirmation_token).not_to be_blank
+    expect_mailer_to_have_delivery(
+      user.email,
+      "password",
+      user.confirmation_token,
+    )
+  end
+
+  def expect_page_to_display_change_password_message
+    expect(page).to have_content I18n.t("passwords.create.description")
+  end
+
+  def expect_mailer_to_have_delivery(recipient, subject, body)
+    expect(ActionMailer::Base.deliveries).not_to be_empty
+
+    message = ActionMailer::Base.deliveries.any? do |email|
+      email.to == [recipient] &&
+        email.subject =~ /#{subject}/i &&
+        email.html_part.body =~ /#{body}/ &&
+        email.text_part.body =~ /#{body}/
+    end
+
+    expect(message).to be
+  end
+
+  def expect_mailer_to_have_no_deliveries
+    expect(ActionMailer::Base.deliveries).to be_empty
+  end
+end

--- a/spec/features/clearance/visitor_signs_in_spec.rb
+++ b/spec/features/clearance/visitor_signs_in_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+require "support/features/clearance_helpers"
+
+RSpec.feature "Visitor signs in" do
+  scenario "with valid email and password" do
+    create_user "user@example.com", "password"
+    sign_in_with "user@example.com", "password"
+
+    expect_user_to_be_signed_in
+  end
+
+  scenario "with valid mixed-case email and password " do
+    create_user "user.name@example.com", "password"
+    sign_in_with "User.Name@example.com", "password"
+
+    expect_user_to_be_signed_in
+  end
+
+  scenario "tries with invalid password" do
+    create_user "user@example.com", "password"
+    sign_in_with "user@example.com", "wrong_password"
+
+    expect_page_to_display_sign_in_error
+    expect_user_to_be_signed_out
+  end
+
+  scenario "tries with invalid email" do
+    sign_in_with "unknown.email@example.com", "password"
+
+    expect_page_to_display_sign_in_error
+    expect_user_to_be_signed_out
+  end
+
+  private
+
+  def create_user(email, password)
+    FactoryBot.create(:user, email: email, password: password)
+  end
+
+  def expect_page_to_display_sign_in_error
+    expect(page.body).to include(
+      I18n.t("flashes.failure_after_create", sign_up_path: sign_up_path),
+    )
+  end
+end

--- a/spec/features/clearance/visitor_signs_up_spec.rb
+++ b/spec/features/clearance/visitor_signs_up_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+require "support/features/clearance_helpers"
+
+RSpec.feature "Visitor signs up" do
+  scenario "by navigating to the page" do
+    visit sign_in_path
+
+    click_link I18n.t("sessions.form.sign_up")
+
+    expect(current_path).to eq sign_up_path
+  end
+
+  scenario "with valid email and password" do
+    sign_up_with "valid@example.com", "password"
+
+    expect_user_to_be_signed_in
+  end
+
+  scenario "tries with invalid email" do
+    sign_up_with "invalid_email", "password"
+
+    expect_user_to_be_signed_out
+  end
+
+  scenario "tries with blank password" do
+    sign_up_with "valid@example.com", ""
+
+    expect_user_to_be_signed_out
+  end
+end

--- a/spec/features/clearance/visitor_updates_password_spec.rb
+++ b/spec/features/clearance/visitor_updates_password_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+require "support/features/clearance_helpers"
+
+RSpec.feature "Visitor updates password" do
+  scenario "with valid password" do
+    user = user_with_reset_password
+    update_password user, "newpassword"
+
+    expect_user_to_be_signed_in
+  end
+
+  scenario "signs in with new password" do
+    user = user_with_reset_password
+    update_password user, "newpassword"
+    sign_out
+    sign_in_with user.email, "newpassword"
+
+    expect_user_to_be_signed_in
+  end
+
+  scenario "tries with a blank password" do
+    user = user_with_reset_password
+    visit_password_reset_page_for user
+    change_password_to ""
+
+    expect(page).to have_content I18n.t("flashes.failure_after_update")
+    expect_user_to_be_signed_out
+  end
+
+  private
+
+  def update_password(user, password)
+    visit_password_reset_page_for user
+    change_password_to password
+  end
+
+  def visit_password_reset_page_for(user)
+    visit edit_user_password_path(
+      user_id: user,
+      token: user.confirmation_token,
+    )
+  end
+
+  def change_password_to(password)
+    fill_in "password_reset_password", with: password
+    click_button I18n.t("helpers.submit.password_reset.submit")
+  end
+end

--- a/spec/support/clearance.rb
+++ b/spec/support/clearance.rb
@@ -1,0 +1,1 @@
+require "clearance/rspec"

--- a/spec/support/features/clearance_helpers.rb
+++ b/spec/support/features/clearance_helpers.rb
@@ -1,0 +1,52 @@
+module Features
+  module ClearanceHelpers
+    def reset_password_for(email)
+      visit new_password_path
+      fill_in "password_email", with: email
+      click_button I18n.t("helpers.submit.password.submit")
+    end
+
+    def sign_in
+      password = "password"
+      user = FactoryBot.create(:user, password: password)
+      sign_in_with user.email, password
+    end
+
+    def sign_in_with(email, password)
+      visit sign_in_path
+      fill_in "session_email", with: email
+      fill_in "session_password", with: password
+      click_button I18n.t("helpers.submit.session.submit")
+    end
+
+    def sign_out
+      click_button I18n.t("layouts.application.sign_out")
+    end
+
+    def sign_up_with(email, password)
+      visit sign_up_path
+      fill_in "user_email", with: email
+      fill_in "user_password", with: password
+      click_button I18n.t("helpers.submit.user.create")
+    end
+
+    def expect_user_to_be_signed_in
+      visit root_path
+      expect(page).to have_button I18n.t("layouts.application.sign_out")
+    end
+
+    def expect_user_to_be_signed_out
+      expect(page).to have_content I18n.t("layouts.application.sign_in")
+    end
+
+    def user_with_reset_password
+      user = FactoryBot.create(:user)
+      reset_password_for user.email
+      user.reload
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include Features::ClearanceHelpers, type: :feature
+end


### PR DESCRIPTION
Add the clearance gem to allow for simple user authentication. Also used
the automatically generated specs that come with clearance. To get these
to work, had to also install factory_bot_rails for factories.