### PR TITLE
Add methods to calculate statistics for mininstries

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -229,7 +229,6 @@ button:focus {
   align-items: center;
   font-size: 14px;
   border-bottom: 1px solid rgb(221, 225, 227);
-  padding-left: 10px;
   border-right: 1px solid rgb(243, 243, 243);
   height: 35px;
 }
@@ -240,6 +239,7 @@ button:focus {
 
  .grid-table-data-text {
   color: #424241;
+  padding-left: 10px;
 }
 
 .pretty-link {
@@ -308,3 +308,33 @@ button:focus {
   padding-top: 25px;
 }
 
+.statistics {
+  margin-left: 65px;
+  padding-top: 20px;
+  display: grid;
+  grid-template-columns: 250px 250px 250px;
+  grid-gap: 20px;
+}
+
+.statistics-item {
+  border: 1px solid rgb(221, 225, 227);
+  border-radius: 5px;
+  height: 100px;
+  width: 250px;
+  display: grid;
+  grid-template-rows: 60px 40px;
+  align-items: center;
+}
+
+.statistics-number {
+  font-size: 45px;
+  text-align: center;
+  font-weight: 600;
+}
+
+.statistics-description {
+  font-size: 14px;
+  display: grid;
+  color: #a5a5a5;
+  text-align: center;
+}

--- a/app/models/ministry.rb
+++ b/app/models/ministry.rb
@@ -2,4 +2,12 @@ class Ministry < ApplicationRecord
   validates_presence_of :name, :director
   belongs_to :director, class_name: 'User'
   has_many :roles
+
+  def number_of_coaches
+    self.roles.where(role_type: 'Coach').count
+  end
+
+  def number_of_leaders
+    self.roles.where(role_type: 'Ministry Leader').count
+  end
 end

--- a/app/views/ministries/show.html.erb
+++ b/app/views/ministries/show.html.erb
@@ -26,6 +26,40 @@
 </div>
 <div class="sub-section-title">
   <div class="sub-section-icon">
+    <i class="fas fa-chart-line"></i>
+  </div>
+  <div class="item-sub-heading-text">
+    Statistics
+  </div>
+</div>
+<div class="statistics">
+  <div class="statistics-item">
+    <div class="statistics-number">
+      <%= @ministry.number_of_coaches %>
+    </div>
+    <div class="statistics-description">
+      Coaches
+    </div>
+  </div>
+  <div class="statistics-item">
+    <div class="statistics-number">
+      <%= @ministry.number_of_leaders %>
+    </div>
+    <div class="statistics-description">
+      Ministry Leaders
+    </div>
+  </div>
+  <div class="statistics-item">
+    <div class="statistics-number">
+      167
+    </div>
+    <div class="statistics-description">
+      Team Members
+    </div>
+  </div>
+</div>
+<div class="sub-section-title">
+  <div class="sub-section-icon">
     <i class="fas fa-users"></i>
   </div>
   <div class="item-sub-heading-text">
@@ -36,6 +70,7 @@
   <div class="grid-table-header">
     <div class="grid-table-header-cell">
       <div class="grid-table-header-icon">
+        <i class="fas fa-align-justify"></i>
       </div>
       <div class="grid-table-header-text">
         Role Name
@@ -43,6 +78,7 @@
     </div>
     <div class="grid-table-header-cell">
       <div class="grid-table-header-icon">
+        <i class="fas fa-list-ul"></i>
       </div>
       <div class="grid-table-header-text">
         Role Type
@@ -50,6 +86,7 @@
     </div>
     <div class="grid-table-header-cell">
       <div class="grid-table-header-icon">
+        <i class="far fa-user"></i>
       </div>
       <div class="grid-table-header-text">
         Team Member


### PR DESCRIPTION
Add number_of_coaches and number_of_leaders methods to ministry models
that calculate the number of each in the ministry.  Also put in a dummy
number for number of team members, which will be updated once this is
part of the model.