### PR TITLE
Add RoleRelationship model.

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -43,7 +43,6 @@ a:active {color:#424242;}  /* selected link */
   font-size: 14px;
   line-height: 16.8px;
   padding-bottom: 25px;
-  border-bottom: 1px solid rgb(242, 242, 242);
 }
 
 .inline-form-new-user {
@@ -187,13 +186,13 @@ button:focus {
 
 .main {
   padding-bottom: 150px;
-  height: auto;
   width: 100%;
-  position: fixed;
+  position: relative;
   top: 0px;
   left: 250px;
   overflow-y: scroll;
   overflow-x: scroll;
+  padding-bottom: 75px;
 }
 
 .grid-table {

--- a/app/controllers/role_relationships_controller.rb
+++ b/app/controllers/role_relationships_controller.rb
@@ -1,0 +1,40 @@
+class RoleRelationshipsController < ApplicationController
+
+  def new
+    @leading_role = Role.find(params[:leading_role])
+    @ministry = @leading_role.ministry
+    @role_relationship = RoleRelationship.new
+    @followers = assign_followers(@leading_role.role_type)
+  end
+
+  def create
+    @role_relationship = RoleRelationship.new(role_relationship_params)
+    @leading_role = Role.find(params[:role_relationship][:leading_role_id])
+    @ministry = @leading_role.ministry
+    @followers = assign_followers(@leading_role.role_type)
+    if @role_relationship.save
+      flash[:success] = 'Linked a new role'
+      redirect_to role_path(@leading_role)
+    else
+      render :new
+    end
+  end
+
+  protected
+
+  def assign_followers(leading_role_type)
+    case leading_role_type
+    when 'Director'
+      @ministry.roles.where(role_type: 'Coach')
+    when 'Coach'
+      @ministry.roles.where(role_type: 'Team Leader')
+    when 'Team Leader'
+      @ministry.roles.where(role_type: 'Team Member')
+    end
+  end
+
+  def role_relationship_params
+    params.require(:role_relationship).permit(:leading_role_id,
+                                              :following_role_id)
+  end
+end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -35,6 +35,7 @@ class RolesController < ApplicationController
   end
 
   def show
+    @followers = @role.followers
   end
 
   protected
@@ -44,7 +45,7 @@ class RolesController < ApplicationController
   end
 
   def set_role_types
-    @role_types = ['Coach', 'Ministry Leader', 'Team Member']
+    @role_types = ['Coach', 'Team Leader', 'Team Member']
   end
 
   def role_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,5 +5,32 @@ module ApplicationHelper
     unique_pc_ids.include?(person_id.to_i)
   end
 
+  def role_relationship_following_role_type(leading_role_type)
+    case leading_role_type
+    when 'Director'
+      'Coach'
+    when 'Coach'
+      'Team Leader'
+    when 'Team Leader'
+      'Team Member'
+    end
+  end
 
+  def role_relationship_leading_role_type(leading_role_type)
+    case leading_role_type
+    when 'Coach'
+      'Director'
+    when 'Team Leader'
+      'Coach'
+    when 'Team Member'
+      'Team Leader'
+    end
+  end
+  def show_leading_role(role)
+    if role.leaders.count > 0
+      role.leaders.first.role_details
+    else
+      "No #{role_relationship_leading_role_type(role.role_type).downcase} assigned"
+    end
+  end
 end

--- a/app/models/ministry.rb
+++ b/app/models/ministry.rb
@@ -4,10 +4,14 @@ class Ministry < ApplicationRecord
   has_many :roles
 
   def number_of_coaches
-    self.roles.where(role_type: 'Coach').count
+    roles.where(role_type: 'Coach').count
   end
 
   def number_of_leaders
-    self.roles.where(role_type: 'Ministry Leader').count
+    roles.where(role_type: 'Team Leader').count
+  end
+
+  def number_of_members
+    roles.where(role_type: 'Team Member').count
   end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,10 +1,24 @@
 class Role < ApplicationRecord
   belongs_to :ministry
   belongs_to :team_member, class_name: 'User'
+
+  has_many :leading_relationships,
+           class_name: 'RoleRelationship',
+           foreign_key: 'leading_role_id'
+  has_many :following_relationships,
+           class_name: 'RoleRelationship',
+           foreign_key: 'following_role_id'
+  has_many :leaders, through: :following_relationships, source: :leading_role
+  has_many :followers, through: :leading_relationships, source: :following_role
   has_many :apprentice_relationships
   has_many :apprentices, through: :apprentice_relationships, foreign_key: 'apprentice_id'
   validates_presence_of :ministry,
                         :team_member,
                         :role_type,
                         :name
+
+  def role_details
+    team_member.full_name + ' - ' + name
+  end
+
 end

--- a/app/models/role_relationship.rb
+++ b/app/models/role_relationship.rb
@@ -1,0 +1,4 @@
+class RoleRelationship < ApplicationRecord
+  belongs_to :leading_role, class_name: 'Role'
+  belongs_to :following_role, class_name: 'Role'
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,9 @@ class User < ApplicationRecord
   has_many :apprenticeships,
            class_name: 'ApprenticeRelationship',
            foreign_key: 'apprentice_id'
+  has_many :leaders,
+           class_name: 'RoleRelationship',
+           foreign_key: 'team_member_id'
 
   default_scope { order( created_at: :desc) }
 

--- a/app/views/ministries/show.html.erb
+++ b/app/views/ministries/show.html.erb
@@ -51,7 +51,7 @@
   </div>
   <div class="statistics-item">
     <div class="statistics-number">
-      167
+      <%= @ministry.number_of_members %>
     </div>
     <div class="statistics-description">
       Team Members

--- a/app/views/role_relationships/_form.html.erb
+++ b/app/views/role_relationships/_form.html.erb
@@ -1,0 +1,40 @@
+<%= form_for @role_relationship do |f| %>
+  <% if @role_relationship.errors.any? %>
+    <div class="form-errors">
+      This couldn't be completed because there are
+      <%= pluralize(@role_relationship.errors.count, 'errors') %>.
+      Please update the form and try again.
+    </div>
+    <ul>
+      <% @role_relationship.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  <% end %>
+  <div class="inline-form">
+    <div class="inline-form-label">
+      <div class="inline-form-label-icon">
+        <i class="far fa-user"></i>
+      </div>
+      <%=
+        f.label :following_role_id,
+          "Select #{role_relationship_following_role_type(@leading_role.role_type)}",
+        class: 'inline-form-label-text'
+      %>
+    </div>
+    <%=
+      f.collection_select :following_role_id,
+      @followers,
+      :id,
+      :role_details,
+      {},
+      {class: 'inline-form-input'}
+    %>
+    <%=
+      f.hidden_field :leading_role_id, value: @leading_role.id
+    %>
+    <%= f.submit @role_relationship.new_record? ? 'Link Role' : 'Update Link',
+      class: 'form-submit-button' %>
+  </div>
+<% end %>
+

--- a/app/views/role_relationships/new.html.erb
+++ b/app/views/role_relationships/new.html.erb
@@ -1,0 +1,5 @@
+<div class="section-heading">
+  Link a new <%= role_relationship_following_role_type(@leading_role.role_type) %>
+</div>
+
+<%= render 'form' %>

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -55,6 +55,17 @@
   <div class="inline-form-text">
     <%= @role.team_member.full_name %>
   </div>
+  <div class="inline-form-label">
+    <div class="inline-form-label-icon">
+      <i class="far fa-user"></i>
+    </div>
+    <div class="inline-form-label-text">
+      <%= role_relationship_leading_role_type(@role.role_type) %>
+    </div>
+  </div>
+  <div class="inline-form-text">
+    <%= show_leading_role(@role) %>
+  </div>
 </div>
 <div class="sub-section-title">
   <div class="sub-section-icon">
@@ -123,3 +134,95 @@
 <% end %>
 
 
+<% if @role.role_type != 'Team Member' %>
+  <div class="sub-section-title">
+    <div class="sub-section-icon">
+      <i class="fas fa-sitemap"></i>
+    </div>
+    <div class="item-sub-heading-text">
+      <%= role_relationship_following_role_type(@role.role_type).pluralize(2) %>
+    </div>
+  </div>
+
+  <div class="grid-table">
+    <div class="grid-table-header">
+      <div class="grid-table-header-cell">
+        <div class="grid-table-header-icon">
+          <i class="fas fa-align-justify"></i>
+        </div>
+        <div class="grid-table-header-text">
+          Role Name
+        </div>
+      </div>
+      <div class="grid-table-header-cell">
+        <div class="grid-table-header-icon">
+          <i class="fas fa-list-ul"></i>
+        </div>
+        <div class="grid-table-header-text">
+          Role Type
+        </div>
+      </div>
+      <div class="grid-table-header-cell">
+        <div class="grid-table-header-icon">
+          <i class="far fa-user"></i>
+        </div>
+        <div class="grid-table-header-text">
+          Team Member
+        </div>
+      </div>
+      <div class="grid-table-header-cell">
+        <div class="grid-table-header-icon">
+          <i class="fas fa-hands-helping"></i>
+        </div>
+        <div class="grid-table-header-text">
+          Apprentice
+        </div>
+      </div>
+    </div>
+    <% @followers.each do |role| %>
+      <div class="grid-table-data">
+        <div class="grid-table-data-cell">
+          <%=
+            link_to role.name,
+              role_path(role),
+              class: 'grid-table-data-text pretty-link'
+            %>
+        </div>
+        <div class="grid-table-data-cell">
+          <div class="grid-table-data-text">
+            <%= role.role_type %>
+          </div>
+        </div>
+        <div class="grid-table-data-cell">
+          <div class="grid-table-data-text">
+            <%= role.team_member.full_name %>
+          </div>
+        </div>
+        <div class="grid-table-data-cell">
+          <div class="grid-table-data-text">
+            <% if role.apprentice_relationships.any? %>
+              <% if role.apprentice_relationships.count == 1 %>
+                <%= role.apprentice_relationships.first.apprentice.full_name %>
+              <% else %>
+                <%= role.apprentice_relationships.count %> apprentices
+              <% end %>
+            <% else %>
+              None
+            <% end %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+    <div class="grid-table-last-row">
+      <div class="grid-table-last-row-icon">
+        <i class="fas fa-plus"></i>
+      </div>
+      <%=
+        link_to 'Link a role',
+          new_role_relationship_path(:leading_role => @role),
+          class: 'grid-table-last-row-text pretty-link'
+        %>
+    </div>
+  </div>
+
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,6 @@ Rails.application.routes.draw do
   resources :roles
   resources :users, only: [:index, :show, :create]
   resources :apprentice_relationships
+  resources :role_relationships, only: [:new, :create]
   post :search_people, to: "search_people#search", as: :search_people
 end

--- a/db/migrate/20180425204711_create_role_relationships.rb
+++ b/db/migrate/20180425204711_create_role_relationships.rb
@@ -1,0 +1,10 @@
+class CreateRoleRelationships < ActiveRecord::Migration[5.1]
+  def change
+    create_table :role_relationships do |t|
+     t.references :role, foreign_key: true
+      t.references :member, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180425210239_change_column_name_from_member_to_team_member.rb
+++ b/db/migrate/20180425210239_change_column_name_from_member_to_team_member.rb
@@ -1,0 +1,5 @@
+class ChangeColumnNameFromMemberToTeamMember < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :role_relationships, :member_id, :team_member_id
+  end
+end

--- a/db/migrate/20180425211634_change_column_from_role_to_leading_role.rb
+++ b/db/migrate/20180425211634_change_column_from_role_to_leading_role.rb
@@ -1,0 +1,5 @@
+class ChangeColumnFromRoleToLeadingRole < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :role_relationships, :role_id, :leading_role_id
+  end
+end

--- a/db/migrate/20180425211738_remove_team_member_id_from_role_relationships.rb
+++ b/db/migrate/20180425211738_remove_team_member_id_from_role_relationships.rb
@@ -1,0 +1,5 @@
+class RemoveTeamMemberIdFromRoleRelationships < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :role_relationships, :team_member_id, :integer
+  end
+end

--- a/db/migrate/20180425211809_add_following_role_to_role_relationships.rb
+++ b/db/migrate/20180425211809_add_following_role_to_role_relationships.rb
@@ -1,0 +1,5 @@
+class AddFollowingRoleToRoleRelationships < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :role_relationships, :following_role, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180420200428) do
+ActiveRecord::Schema.define(version: 20180425211809) do
 
   create_table "apprentice_relationships", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -25,6 +25,15 @@ ActiveRecord::Schema.define(version: 20180420200428) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "director_id"
+  end
+
+  create_table "role_relationships", force: :cascade do |t|
+    t.integer "leading_role_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "following_role_id"
+    t.index ["following_role_id"], name: "index_role_relationships_on_following_role_id"
+    t.index ["leading_role_id"], name: "index_role_relationships_on_leading_role_id"
   end
 
   create_table "roles", force: :cascade do |t|

--- a/spec/factories/role_relationships.rb
+++ b/spec/factories/role_relationships.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :role_relationship do
+    role
+    association :member, factory: :user
+  end
+end

--- a/spec/features/apprentice_spec.rb
+++ b/spec/features/apprentice_spec.rb
@@ -7,7 +7,7 @@ describe 'Apprentice' do
     @ministry = Ministry.create(name: 'Ministry', director: @director)
     @leader = FactoryBot.create(:user)
     @role = Role.create(name: 'Test Role',
-                        role_type: 'Ministry Leader',
+                        role_type: 'Team Leader',
                         team_member: @leader,
                         ministry: @ministry)
     @apprentice = FactoryBot.create(:user)

--- a/spec/features/coach_relationship_spec.rb
+++ b/spec/features/coach_relationship_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+require 'support/features/clearance_helpers'
+
+describe 'Create' do
+  before do
+    @director = FactoryBot.create(:user)
+    @ministry = Ministry.create(name: 'Ministry', director: @director)
+    @coach = FactoryBot.create(:user)
+    @leader = FactoryBot.create(:user, first_name: "Leader", last_name: "Person")
+    @member = FactoryBot.create(:user, first_name: "Member", last_name: "Person")
+    @role = Role.create(
+      name: 'Coach role',
+      role_type: 'Coach',
+      team_member: @coach,
+      ministry: @ministry
+    )
+    @role2 = Role.create(
+      name: 'Leader role',
+      role_type: 'Team Leader',
+      team_member: @leader,
+      ministry: @ministry
+    )
+    @role3 = Role.create(
+      name: 'Team Member Role',
+      role_type: 'Team Member',
+      team_member: @member,
+      ministry: @ministry
+    )
+    sign_in_with(@director.email, @director.password)
+  end
+
+  it 'has the option to add a coaching relationship if the role is coach or team leader' do
+    visit role_path(@role)
+    expect(page).to have_content('Link a role')
+  end
+
+  it 'does not have the option to link team leaders if the role_type is team member' do
+    visit role_path(@role3)
+    expect(page).to_not have_content('Link a role')
+  end
+
+  it 'shows team leaders linked to a coach role' do
+    RoleRelationship.create(leading_role: @role,
+                            following_role: @role2)
+    visit role_path(@role)
+    expect(page).to have_content(@role2.name)
+  end
+
+  it 'takes you to the new relationship page' do
+    RoleRelationship.create(leading_role: @role,
+                            following_role: @role2)
+    visit role_path(@role)
+    click_on('Link a role')
+    expect(current_path).to eq(new_role_relationship_path)
+  end
+
+  it 'can select from only team leaders if the leader is a coach' do
+    visit role_path(@role)
+    click_on('Link a role')
+    expect(page).to have_select('role_relationship_following_role_id', with_options: ['Leader Person - Leader role'])
+    expect(page).to_not have_select('role_relationship_following_role_id', with_options: ['Member Person - Team Member Role'])
+  end
+
+  it 'can select from only team members if the leader is a team leader' do
+    visit role_path(@role2)
+    click_on('Link a role')
+    expect(page).to have_select('role_relationship_following_role_id', with_options: ['Member Person - Team Member Role'])
+    expect(page).to_not have_select('role_relationship_following_role_id', with_options: ['Leader Person - Leader role'])
+
+  end
+
+  it 'can create a new role relationship' do
+    before_count = RoleRelationship.count
+    visit role_path(@role)
+    click_on('Link a role')
+    select('Leader Person - Leader role', from: 'role_relationship_following_role_id')
+    click_on('Link Role')
+    expect(current_path).to eq(role_path(@role))
+    expect(RoleRelationship.count).to eq(before_count + 1)
+  end
+
+  it 'shows all linked roles on the role show page' do
+    visit role_path(@role)
+    click_on('Link a role')
+    select('Leader Person - Leader role', from: 'role_relationship_following_role_id')
+    click_on('Link Role')
+    expect(page).to have_content('Leader Person')
+  end
+
+
+
+end

--- a/spec/features/role_spec.rb
+++ b/spec/features/role_spec.rb
@@ -38,4 +38,18 @@ describe 'Role' do
     visit role_path(role)
     expect(current_path).to eq(role_path(role))
   end
+
+  it 'shows the coach if the role_type is Team Leader' do
+    leader_role = FactoryBot.create(:role,
+                                    ministry: @ministry,
+                                    role_type: 'Team Leader')
+    coach_role = FactoryBot.create(:role,
+                                   ministry: @ministry,
+                                   role_type: 'Coach')
+    RoleRelationship.create(following_role: leader_role, leading_role: coach_role)
+    visit role_path(leader_role)
+    expect(page).to have_content('Coach')
+    expect(page).to have_content(coach_role.team_member.full_name + " - " + coach_role.name)
+
+  end
 end

--- a/spec/models/role_relationship_spec.rb
+++ b/spec/models/role_relationship_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe RoleRelationship, type: :model do
+  before do
+    @role_relationship = RoleRelationship.create(leading_role: FactoryBot.create(:role), following_role: FactoryBot.create(:role))
+  end
+
+  it 'can be created with valid parameters' do
+    expect(@role_relationship).to be_valid
+  end
+end


### PR DESCRIPTION
Role relationships show the connections between team members and team
leaders, and between team leaders and coaches. Users can now link team
member to team leader roles and team leader to coach roles. Once
relevant team members from the ministry are shown when linking (i.e.
when linking to a coaching role, only team leaders from the same
ministry are shown)