### PR TITLE
Add method to calculate percent apprenticing

### DIFF
--- a/app/models/ministry.rb
+++ b/app/models/ministry.rb
@@ -14,4 +14,16 @@ class Ministry < ApplicationRecord
   def number_of_members
     roles.where(role_type: 'Team Member').count
   end
+
+  def percent_having_apprentice(role_type)
+    total_roles = roles.where(role_type: role_type)
+    return 0 if total_roles.count == 0
+    i = 0
+    total_roles.each do |role|
+      if role.apprentices.count > 0
+        i += 1
+      end
+    end
+    (i.to_f/total_roles.count.to_f * 100).round(0)
+  end
 end

--- a/app/views/ministries/show.html.erb
+++ b/app/views/ministries/show.html.erb
@@ -38,7 +38,7 @@
       <%= @ministry.number_of_coaches %>
     </div>
     <div class="statistics-description">
-      Coaches
+      <%= 'Coach'.pluralize(@ministry.number_of_coaches) %>
     </div>
   </div>
   <div class="statistics-item">
@@ -46,7 +46,7 @@
       <%= @ministry.number_of_leaders %>
     </div>
     <div class="statistics-description">
-      Ministry Leaders
+      <%= 'Team Leader'.pluralize(@ministry.number_of_leaders) %>
     </div>
   </div>
   <div class="statistics-item">
@@ -54,7 +54,25 @@
       <%= @ministry.number_of_members %>
     </div>
     <div class="statistics-description">
-      Team Members
+      <%= 'Team Member'.pluralize(@ministry.number_of_members) %>
+    </div>
+  </div>
+</div>
+<div class="statistics">
+  <div class="statistics-item">
+    <div class="statistics-number">
+      <%= @ministry.percent_having_apprentice('Coach') %>%
+    </div>
+    <div class="statistics-description">
+      of coaches have an apprentice
+    </div>
+  </div>
+  <div class="statistics-item">
+    <div class="statistics-number">
+      <%= @ministry.percent_having_apprentice('Team Leader') %>%
+    </div>
+    <div class="statistics-description">
+      of team leaders have an apprentice
     </div>
   </div>
 </div>

--- a/spec/models/ministry_spec.rb
+++ b/spec/models/ministry_spec.rb
@@ -20,4 +20,44 @@ RSpec.describe Ministry, type: :model do
       expect(@ministry).to_not be_valid
     end
   end
+
+  describe 'metrics' do
+    before do
+      @ministry = FactoryBot.create(:ministry)
+    end
+    it 'calculates the percentage of coaches that have an apprentice' do
+      @role1 = Role.create(name: "Role 1",
+                           ministry: @ministry,
+                           role_type: "Coach",
+                           team_member: FactoryBot.create(:user))
+      @role2 = Role.create(name: "Role 1",
+                           ministry: @ministry,
+                           role_type: "Coach",
+                           team_member: FactoryBot.create(:user))
+      @role3 = Role.create(name: "Role 1",
+                           ministry: @ministry,
+                           role_type: "Coach",
+                           team_member: FactoryBot.create(:user))
+      FactoryBot.create(:apprentice_relationship, role: @role1)
+      expect(@ministry.percent_having_apprentice('Coach')).to eq(33)
+    end
+
+    it 'calculates the percentage of leaders that have an apprentice' do
+      @role1 = Role.create(name: "Role 1",
+                           ministry: @ministry,
+                           role_type: "Team Leader",
+                           team_member: FactoryBot.create(:user))
+      @role2 = Role.create(name: "Role 1",
+                           ministry: @ministry,
+                           role_type: "Team Leader",
+                           team_member: FactoryBot.create(:user))
+      @role3 = Role.create(name: "Role 1",
+                           ministry: @ministry,
+                           role_type: "Team Leader",
+                           team_member: FactoryBot.create(:user))
+      FactoryBot.create(:apprentice_relationship, role: @role1)
+      expect(@ministry.percent_having_apprentice('Team Leader')).to eq(33)
+
+    end
+  end
 end


### PR DESCRIPTION
Add new method to Ministry that takes in a role type and calculates the
% of that role type that has an apprentice.  Display this value on the
ministry show page, in the statistics section.