### PR TITLE
Role updating

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -30,6 +30,8 @@ a:active {color:#424242;}  /* selected link */
   font-weight: 400;
   margin-bottom: 10px;
   margin-left: 65px;
+  margin-right: 65px;
+  width: 750px;
 }
 
 .inline-form {

--- a/app/controllers/ministries_controller.rb
+++ b/app/controllers/ministries_controller.rb
@@ -34,7 +34,7 @@ class MinistriesController < ApplicationController
   end
 
   def show
-    @roles = @ministry.roles.paginate(:page => params[:page], :per_page => 15)
+    @roles = @ministry.roles.where(active: true).paginate(:page => params[:page], :per_page => 15)
   end
 
   protected

--- a/app/controllers/role_relationships_controller.rb
+++ b/app/controllers/role_relationships_controller.rb
@@ -25,11 +25,11 @@ class RoleRelationshipsController < ApplicationController
   def assign_followers(leading_role_type)
     case leading_role_type
     when 'Director'
-      @ministry.roles.where(role_type: 'Coach')
+      @ministry.roles.where(role_type: 'Coach', active: true)
     when 'Coach'
-      @ministry.roles.where(role_type: 'Team Leader')
+      @ministry.roles.where(role_type: 'Team Leader', active: true)
     when 'Team Leader'
-      @ministry.roles.where(role_type: 'Team Member')
+      @ministry.roles.where(role_type: 'Team Member', active: true)
     end
   end
 

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -2,7 +2,7 @@ class RolesController < ApplicationController
   before_action :require_login
   before_action :set_users, only: [:new, :edit, :update]
   before_action :set_role_types, only: [:new, :create, :edit, :update]
-  before_action :set_role, only: [:edit, :update, :show]
+  before_action :set_role, only: [:edit, :update, :show, :destroy]
 
   def new
     @role = Role.new
@@ -28,7 +28,12 @@ class RolesController < ApplicationController
     @ministry = @role.ministry
     if @role.update(role_params)
       flash[:success] = 'Role updated'
-      redirect_to ministry_path(@ministry)
+      if params[:set_inactive]
+        RoleRelationship.where(leading_role: @role).delete_all
+        redirect_to ministry_path(@ministry)
+      else
+        redirect_to role_path(@role)
+      end
     else
       render :edit
     end
@@ -36,6 +41,14 @@ class RolesController < ApplicationController
 
   def show
     @followers = @role.followers
+  end
+
+  def destroy
+    @ministry = @role.ministry
+    @role.delete
+    RoleRelationship.where(leading_role: @role).delete_all
+    flash[:success] = 'Role was removed'
+    redirect_to ministry_path(@ministry)
   end
 
   protected
@@ -53,7 +66,8 @@ class RolesController < ApplicationController
       :name,
       :role_type,
       :team_member_id,
-      :ministry_id
+      :ministry_id,
+      :active
     )
   end
 

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -30,6 +30,7 @@ class RolesController < ApplicationController
       flash[:success] = 'Role updated'
       if params[:set_inactive]
         RoleRelationship.where(leading_role: @role).delete_all
+        ApprenticeRelationship.where(role: @role).delete_all
         @role.set_inactive_at = Time.now
         @role.save
         redirect_to ministry_path(@ministry)
@@ -49,6 +50,7 @@ class RolesController < ApplicationController
     @ministry = @role.ministry
     @role.delete
     RoleRelationship.where(leading_role: @role).delete_all
+    ApprenticeRelationship.where(role: @role).delete_all
     flash[:success] = 'Role was removed'
     redirect_to ministry_path(@ministry)
   end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -30,6 +30,8 @@ class RolesController < ApplicationController
       flash[:success] = 'Role updated'
       if params[:set_inactive]
         RoleRelationship.where(leading_role: @role).delete_all
+        @role.set_inactive_at = Time.now
+        @role.save
         redirect_to ministry_path(@ministry)
       else
         redirect_to role_path(@role)

--- a/app/controllers/update_roles_controller.rb
+++ b/app/controllers/update_roles_controller.rb
@@ -1,0 +1,6 @@
+class UpdateRolesController < ApplicationController
+
+  def show
+    @role = Role.find(params[:role])
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,8 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @roles = @user.roles
+    @active_roles = @user.roles.where(active: true)
+    @inactive_roles = @user.roles.where(active: false)
     @apprenticeships = @user.apprenticeships
   end
 

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -20,18 +20,9 @@
       </div>
       <%=
         link_to 'Update',
-        edit_role_path(@role),
-        class: 'action-item-text pretty-link'
-      %>
-    </div>
-    <div class="action-item">
-      <div class="action-item-icon">
-      </div>
-      <%=
-        link_to 'Delete',
-        role_path(@role),
-        method: :delete,
-        class: 'action-item-text pretty-link'
+        update_role_path(:role => @role),
+        class: 'action-item-text pretty-link',
+        id: 'update_role_link'
       %>
     </div>
   </div>

--- a/app/views/update_roles/show.html.erb
+++ b/app/views/update_roles/show.html.erb
@@ -1,0 +1,134 @@
+<div class="breadcrumbs">
+  <%=
+    link_to 'Ministries',
+    ministries_path
+  %> /
+  <%=
+    link_to @role.ministry.name,
+    ministry_path(@role.ministry)
+  %> /
+  Roles /
+  <%=
+    link_to @role.name,
+    role_path(@role)
+  %> /
+  Update Role
+</div>
+<div class="section-heading">
+  Update <%= @role.name %>
+</div>
+<div class="sub-section-title">
+  <div class="sub-section-icon">
+    <i class="fas fa-list-ul"></i>
+  </div>
+  <div class="item-sub-heading-text">
+    Details
+  </div>
+</div>
+<div class="inline-form">
+  <div class="inline-form-label">
+    <div class="inline-form-label-icon">
+      <i class="fas fa-list-ul"></i>
+    </div>
+    <div class="inline-form-label-text">
+      Role Type
+    </div>
+  </div>
+  <div class="inline-form-text">
+    <%= @role.role_type %>
+  </div>
+  <div class="inline-form-label">
+    <div class="inline-form-label-icon">
+      <i class="far fa-user"></i>
+    </div>
+    <div class="inline-form-label-text">
+      Team Member
+    </div>
+  </div>
+  <div class="inline-form-text">
+    <%= @role.team_member.full_name %>
+  </div>
+</div>
+<div class="sub-section-title">
+  <div class="sub-section-icon">
+    <i class="fas fa-pencil-alt"></i>
+  </div>
+  <div class="item-sub-heading-text">
+    Update Role Name
+  </div>
+</div> 
+<div class="section-sub-heading">
+  Use this option to update the title of the role. Note that this should only
+  be used if the role is the same, but the title has changed. If the team member
+  is actually in a new role, this role should be marked as inactive, and a new 
+  role should be created.
+</div>
+<div class="inline-form">
+  <div class="inline-form-label">
+    <div class="inline-form-label-icon">
+      <i class="fas fa-pencil-alt"></i>
+    </div>
+    <div class="inline-form-label-text">
+      Update Name
+    </div>
+  </div>
+  <div class="inline-form-text">
+    <%=
+      link_to 'Click here to update',
+      edit_role_path(@role),
+      id: 'edit_role_title',
+      class: 'pretty-link'
+    %>
+  </div>
+</div>
+<div class="sub-section-title">
+  <div class="sub-section-icon">
+    <i class="fas fa-minus-circle"></i>
+  </div>
+  <div class="item-sub-heading-text">
+    Delete Role
+  </div>
+</div> 
+<div class="section-sub-heading">
+  LeaderBuilder keeps a history of roles to track the progression of leadership
+  development. To ensure this history is accurate, please let us know why you
+  would like to remove this role.
+</div>
+<div class="inline-form">
+  <div class="inline-form-label">
+    <div class="inline-form-label-icon">
+      <i class="fas fa-undo"></i>
+    </div>
+    <div class="inline-form-label-text">
+      Accidental Entry
+    </div>
+  </div>
+  <div class="inline-form-text">
+    <%=
+      link_to 'This role was added by accident - it never should have been here.',
+      role_path(@role),
+      method: :delete,
+      data: { confirm: 'Are you sure you want to remove this role?' },
+      id: 'delete_mistakenly_added',
+      class: 'pretty-link'
+    %>
+  </div>
+  <div class="inline-form-label">
+    <div class="inline-form-label-icon">
+      <i class="far fa-minus-square"></i>
+    </div>
+    <div class="inline-form-label-text">
+      Remove Role
+    </div>
+  </div>
+  <div class="inline-form-text">
+    <%=
+      link_to 'This role is no longer active',
+      role_path(@role, role: { active: false }, set_inactive: true),
+      method: :put,
+      data: { confirm: 'Are you sure you want to set this role to inactive?' },
+      id: 'set_role_to_inactive',
+      class: 'pretty-link'
+    %>
+  </div>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,7 +2,7 @@
   Add Team Members
 </div>
 <div class="section-sub-heading">
-  Enter a last name to search Planning Center
+  enter a last name to search planning center
 </div>
 <%= form_tag search_people_path, remote: true do %>
   <div class="inline-form-new-user" style="border:none;">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -29,7 +29,7 @@
     <i class="fas fa-users"></i>
   </div>
   <div class="item-sub-heading-text">
-    Roles
+    Active Roles
   </div>
 </div>
 <div class="grid-table">
@@ -59,7 +59,7 @@
       </div>
     </div>
   </div>
-  <% @roles.each do |role| %>
+  <% @active_roles.each do |role| %>
     <div class="grid-table-data">
       <div class="grid-table-data-cell">
         <%=
@@ -198,7 +198,7 @@
       </div>
     </div>
   </div>
-  <% @roles.each do |role| %>
+  <% @active_roles.each do |role| %>
     <% role.apprentices.each do |apprentice| %>
       <div class="grid-table-data">
         <div class="grid-table-data-cell">
@@ -227,5 +227,62 @@
         </div>
       </div>
     <% end %>
+  <% end %>
+</div>
+<div class="sub-section-title">
+  <div class="sub-section-icon">
+    <i class="fas fa-users"></i>
+  </div>
+  <div class="item-sub-heading-text">
+    Past Roles
+  </div>
+</div>
+<div class="grid-table">
+  <div class="grid-table-header">
+    <div class="grid-table-header-cell">
+      <div class="grid-table-header-icon">
+        <i class="fas fa-align-justify"></i>
+      </div>
+      <div class="grid-table-header-text">
+        Role Name
+      </div>
+    </div>
+    <div class="grid-table-header-cell">
+      <div class="grid-table-header-icon">
+        <i class="fas fa-list-ul"></i>
+      </div>
+      <div class="grid-table-header-text">
+        Role Type
+      </div>
+    </div>
+    <div class="grid-table-header-cell">
+      <div class="grid-table-header-icon">
+        <i class="fas fa-hand-holding-heart"></i>
+      </div>
+      <div class="grid-table-header-text">
+        Ministry
+      </div>
+    </div>
+  </div>
+  <% @inactive_roles.each do |role| %>
+    <div class="grid-table-data">
+      <div class="grid-table-data-cell">
+        <%=
+          link_to role.name,
+          role_path(role),
+          class: 'grid-table-data-text pretty-link'
+        %>
+      </div>
+      <div class="grid-table-data-cell">
+        <div class="grid-table-data-text">
+          <%= role.role_type %>
+        </div>
+      </div>
+      <div class="grid-table-data-cell">
+        <div class="grid-table-data-text">
+          <%= role.ministry.name %>
+        </div>
+      </div>
+    </div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,7 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :show, :create]
   resources :apprentice_relationships
   resources :role_relationships, only: [:new, :create]
+
+  get :update_role, to: "update_roles#show", as: :update_role
   post :search_people, to: "search_people#search", as: :search_people
 end

--- a/db/migrate/20180430204811_add_active_status_to_roles.rb
+++ b/db/migrate/20180430204811_add_active_status_to_roles.rb
@@ -1,0 +1,5 @@
+class AddActiveStatusToRoles < ActiveRecord::Migration[5.1]
+  def change
+    add_column :roles, :active, :boolean
+  end
+end

--- a/db/migrate/20180430204934_add_default_to_active_roles.rb
+++ b/db/migrate/20180430204934_add_default_to_active_roles.rb
@@ -1,0 +1,5 @@
+class AddDefaultToActiveRoles < ActiveRecord::Migration[5.1]
+  def change
+    change_column :roles, :active, :boolean, :default => true
+  end
+end

--- a/db/migrate/20180430223450_add_set_inactive_at_to_roles.rb
+++ b/db/migrate/20180430223450_add_set_inactive_at_to_roles.rb
@@ -1,0 +1,5 @@
+class AddSetInactiveAtToRoles < ActiveRecord::Migration[5.1]
+  def change
+    add_column :roles, :set_inactive_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180425211809) do
+ActiveRecord::Schema.define(version: 20180430204934) do
 
   create_table "apprentice_relationships", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 20180425211809) do
     t.integer "ministry_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "active", default: true
     t.index ["ministry_id"], name: "index_roles_on_ministry_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180430204934) do
+ActiveRecord::Schema.define(version: 20180430223450) do
 
   create_table "apprentice_relationships", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20180430204934) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "active", default: true
+    t.datetime "set_inactive_at"
     t.index ["ministry_id"], name: "index_roles_on_ministry_id"
   end
 

--- a/spec/features/ministry_spec.rb
+++ b/spec/features/ministry_spec.rb
@@ -47,4 +47,13 @@ describe 'Mininstry' do
     expect(page).to have_content(role3.name)
   end
 
+  it 'shows only active roles' do
+    ministry = FactoryBot.create(:ministry)
+    active_role = FactoryBot.create(:role, ministry: ministry)
+    inactive_role = FactoryBot.create(:role, ministry: ministry, active: false)
+    visit ministry_path(ministry)
+    expect(page).to have_content(active_role.team_member.full_name)
+    expect(page).to_not have_content(inactive_role.team_member.full_name)
+  end
+
 end

--- a/spec/features/role_spec.rb
+++ b/spec/features/role_spec.rb
@@ -79,6 +79,16 @@ describe 'Role' do
     expect(RoleRelationship.count).to eq(0)
   end
 
+  it 'removes all apprentice relationships when deleted' do
+    leading_role = FactoryBot.create(:role, role_type: 'Coach')
+    apprentice_role = FactoryBot.create(:role, role_type: 'Team Leader')
+    ApprenticeRelationship.create(role: leading_role,
+                                  apprentice: apprentice_role.team_member)
+    visit update_role_path(:role => leading_role)
+    click_on('delete_mistakenly_added')
+    expect(leading_role.apprentice_relationships.count).to eq(0)
+  end
+
   it 'sets the role active status to false if the role is not longer active' do
     role = FactoryBot.create(:role)
     ministry = role.ministry
@@ -103,6 +113,16 @@ describe 'Role' do
     visit update_role_path(:role => leading_role)
     click_on('set_role_to_inactive')
     expect(leading_role.following_relationships.count).to eq(0)
+  end
+
+  it 'removes all apprentice relationships when role active statis changed to false' do
+    leading_role = FactoryBot.create(:role, role_type: 'Coach')
+    apprentice_role = FactoryBot.create(:role, role_type: 'Team Leader')
+    ApprenticeRelationship.create(role: leading_role,
+                                  apprentice: apprentice_role.team_member)
+    visit update_role_path(:role => leading_role)
+    click_on('set_role_to_inactive')
+    expect(leading_role.apprentice_relationships.count).to eq(0)
   end
 
   it 'can have its title edited' do

--- a/spec/features/role_spec.rb
+++ b/spec/features/role_spec.rb
@@ -88,6 +88,14 @@ describe 'Role' do
     expect(current_path).to eq(ministry_path(ministry))
   end
 
+  it 'sets set_inactive_at to now when role marked as inactive' do
+    role = FactoryBot.create(:role)
+    visit update_role_path(:role => role)
+    click_on('set_role_to_inactive')
+    expect(role.reload.set_inactive_at).to_not eq(nil)
+
+  end
+
   it 'removes all role relationships when role active status is changed to false' do
     leading_role = FactoryBot.create(:role, role_type: 'Coach')
     following_role = FactoryBot.create(:role, role_type: 'Team Leader')

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe Role, type: :model do
       @role.role_type = ''
       expect(@role).to_not be_valid
     end
+
+    it 'is set to active by default' do
+      expect(@role.active).to eq(true)
+    end
   end
 
 end


### PR DESCRIPTION
Roles can be updated to do the following:

- Change the role name
- Delete the role (if it was added in error)
- Mark the role as inactive (if the team member is no longer in the role)

When roles are marked as inactive or deleted, all RoleRelationships are deleted as well.  

Ministry show page now shows only active roles.  On User show pages, active and inactive roles are separated.